### PR TITLE
fix: restringe pendencias por admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Bot de WhatsApp em Node.js voltado para registro de conversas e envio de resumos
 ## Funcionalidades principais
 
 - **Integração com o WhatsApp** através da biblioteca `whatsapp-web.js` com autenticação `LocalAuth`.
-- **Comandos básicos**: responde `!ping` com `pong` e envia o resumo de pendências quando recebe `!pendencias` do administrador.
+- **Comandos básicos**: responde `!ping` com `pong` e envia o resumo de pendências quando recebe `!pendencias` do administrador definido em `WHATSAPP_ADMIN_NUMBER`.
 - **Armazenamento de mensagens**: as conversas do dia são salvas em `chats_salvos/chats-YYYY-MM-DD.json`.
 - **Resumos automáticos**: uma tarefa `cron` é executada às 23:50 para salvar as conversas e disparar um e-mail com o resumo do dia.
 - **Envio de e-mail**: utiliza `nodemailer` com uma conta Gmail para enviar resumos completos ou apenas de pendências.
@@ -38,6 +38,7 @@ EMAIL_USER=seu_usuario@gmail.com
 EMAIL_PASSWORD=senha_de_aplicativo
 EMAIL_TO=destinatario@gmail.com
 ```
+O valor de `WHATSAPP_ADMIN_NUMBER` define qual contato está autorizado a usar o comando `!pendencias`.
 Para que o envio de e-mails funcione é necessário criar uma senha de aplicativo no Gmail e habilitar o acesso às APIs necessárias.
 
 ## Executando localmente

--- a/src/index.js
+++ b/src/index.js
@@ -52,11 +52,11 @@ const saveDailyChats = () => {
 process.on('uncaughtException', (err, origin) => {
   const fsSync = require('fs');
   const pathSync = require('path');
-  console.error(`\n====== UNCAUGHT EXCEPTION ======\n`);
-  console.error(`Timestamp: ${new Date().toISOString()}`);
-  console.error(`Origem: ${origin}`);
-  console.error(err);
-  console.error(`\n==============================\n`);
+  logger.error('====== UNCAUGHT EXCEPTION ======');
+  logger.error(`Timestamp: ${new Date().toISOString()}`);
+  logger.error(`Origem: ${origin}`);
+  logger.error(err);
+  logger.error('==============================');
   try {
     const logsDir = pathSync.join(__dirname, 'logs');
     if (!fsSync.existsSync(logsDir)) fsSync.mkdirSync(logsDir, { recursive: true });
@@ -66,13 +66,13 @@ process.on('uncaughtException', (err, origin) => {
   }
 });
 
-process.on('unhandledRejection', (reason, promise) => {
+process.on('unhandledRejection', (reason) => {
   const fsSync = require('fs');
   const pathSync = require('path');
-  console.error(`\n====== UNHANDLED REJECTION ======\n`);
-  console.error(`Timestamp: ${new Date().toISOString()}`);
-  console.error('Motivo do Rejection:', reason);
-  console.error(`\n===============================\n`);
+  logger.error('====== UNHANDLED REJECTION ======');
+  logger.error(`Timestamp: ${new Date().toISOString()}`);
+  logger.error('Motivo do Rejection:', reason);
+  logger.error('===============================');
   try {
     const logsDir = pathSync.join(__dirname, 'logs');
     if (!fsSync.existsSync(logsDir)) fsSync.mkdirSync(logsDir, { recursive: true });
@@ -159,7 +159,7 @@ client.on('message', async msg => {
     if (msg.body === '!ping') {
       await msg.reply('pong');
       logger.info(`Respondeu pong para !ping de ${msg.from}`);
-    } else if (msg.body === '!pendencias' && msg.fromMe) {
+    } else if (msg.body === '!pendencias' && msg.from === process.env.WHATSAPP_ADMIN_NUMBER) {
       logger.info('Comando !pendencias recebido. Gerando e enviando resumo...');
       // Carrega as conversas do dia para análise
       const todayStr = new Date().toISOString().slice(0, 10);


### PR DESCRIPTION
## Summary
- document admin variable in README
- replace console usage with winston logger
- enforce admin check on `!pendencias` command

## Testing
- `npx eslint src/index.js`
- `npx eslint src/emailer.js`
- `node src/test-summary.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6855ba858b588333a6a9e23d1d3b2cd2