### PR TITLE
Fix Chrome path for puppeteer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ DEFAULT_SUMMARY_DAYS=7
 EMAIL_USER=seu_usuario@gmail.com
 EMAIL_PASSWORD=senha_de_aplicativo
 EMAIL_TO=destinatario@gmail.com
+# Caminho para o executável do Chrome em ambientes de produção
+# (ajuste se necessário)
+CHROMIUM_PATH=/usr/bin/google-chrome-stable

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ DEFAULT_SUMMARY_DAYS=7
 EMAIL_USER=seu_usuario@gmail.com
 EMAIL_PASSWORD=senha_de_aplicativo
 EMAIL_TO=destinatario@gmail.com
+CHROMIUM_PATH=/usr/bin/google-chrome-stable
 ```
 O valor de `WHATSAPP_ADMIN_NUMBER` define qual contato está autorizado a usar o comando `!pendencias`.
 Para que o envio de e-mails funcione é necessário criar uma senha de aplicativo no Gmail e habilitar o acesso às APIs necessárias.

--- a/src/index.js
+++ b/src/index.js
@@ -97,8 +97,9 @@ const client = new Client({
             // '--single-process', // Remova se causar problemas; às vezes necessário em ambientes restritos
             '--disable-gpu'
         ],
-        // Para Windows, se rodar fora do Docker e o Chrome não for encontrado:
-        // executablePath: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe', 
+        // Caso o Chromium não seja baixado automaticamente (como em ambientes
+        // de deploy restritos), use o Chrome instalado no sistema.
+        executablePath: process.env.CHROMIUM_PATH || '/usr/bin/google-chrome-stable'
     }
 });
 


### PR DESCRIPTION
## Summary
- configure chrome path fallback to prevent missing browser error
- document new `CHROMIUM_PATH` env variable

## Testing
- `npx eslint src --config eslint.config.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855d5d3320883339d7e830470aa00d1