### PR TITLE
Implementa resumo de dias múltiplos

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ EMAIL_TO=schieste87@gmail.com
 CHROMIUM_PATH=/usr/bin/google-chrome-stable
 ```
 O valor de `WHATSAPP_ADMIN_NUMBER` define qual contato está autorizado a usar o comando `!pendencias`.
+O `DEFAULT_SUMMARY_DAYS` controla quantos dias entram no resumo diário automático.
 Para que o envio de e-mails funcione é necessário criar uma senha de aplicativo no Gmail e habilitar o acesso às APIs necessárias.
 
 ## Executando localmente

--- a/src/emailer.js
+++ b/src/emailer.js
@@ -96,6 +96,23 @@ function loadChatsByDate(dateStr) {
 }
 
 /**
+ * Carrega as mensagens dos últimos `days` dias, incluindo o dia atual.
+ *
+ * @param {number} days - Quantidade de dias a buscar.
+ * @returns {Array} Array de mensagens combinadas.
+ */
+function loadChatsForLastDays(days) {
+  const allMessages = [];
+  for (let i = 0; i < days; i++) {
+    const date = new Date();
+    date.setDate(date.getDate() - i);
+    const dateStr = date.toISOString().slice(0, 10);
+    allMessages.push(...loadChatsByDate(dateStr));
+  }
+  return allMessages;
+}
+
+/**
  * Envia o resumo das conversas de um dia específico por e-mail.
  * @param {string} dateStr - Data no formato YYYY-MM-DD
  */
@@ -103,6 +120,19 @@ async function sendSummaryForDate(dateStr) {
   const chats = loadChatsByDate(dateStr);
   if (!chats || chats.length === 0) {
     logger.info(`Nenhuma conversa encontrada para ${dateStr}`);
+    return;
+  }
+  await sendDailySummary(chats);
+}
+
+/**
+ * Envia o resumo dos últimos `days` dias por e-mail.
+ * @param {number} days - Quantidade de dias a incluir no resumo.
+ */
+async function sendSummaryForLastDays(days) {
+  const chats = loadChatsForLastDays(days);
+  if (chats.length === 0) {
+    logger.info(`Nenhuma conversa encontrada nos últimos ${days} dias`);
     return;
   }
   await sendDailySummary(chats);
@@ -118,5 +148,7 @@ module.exports = {
   sendDailySummary,
   sendPendingSummary,
   sendSummaryForDate,
-  loadChatsByDate
+  loadChatsByDate,
+  loadChatsForLastDays,
+  sendSummaryForLastDays
 };

--- a/src/index.js
+++ b/src/index.js
@@ -93,8 +93,8 @@ client.on('ready', () => {
     '50 23 * * *',
     () => {
       logger.info('[CRON] Executando tarefa de resumo diário...');
-      const todayStr = new Date().toISOString().slice(0, 10);
-      emailer.sendSummaryForDate(todayStr);
+      const days = parseInt(process.env.DEFAULT_SUMMARY_DAYS || '1', 10);
+      emailer.sendSummaryForLastDays(days);
     },
     {
       scheduled: true,

--- a/src/summarizer.js
+++ b/src/summarizer.js
@@ -74,13 +74,11 @@ function generateSummary(chats) {
     let enviadas = 0;
     let recebidas = 0;
     let ultimaMsg = null;
-    let ultimaMsgFromMe = null;
-    let ultimaMsgFromContato = null;
     let tempos = [];
     let lastFromContato = null;
     let lastFromMe = null;
     let temasDetectados = new Set();
-    chat.messages.forEach((messageObj, idx) => {
+    chat.messages.forEach((messageObj) => {
       const text =
         typeof messageObj === 'string' ? messageObj : messageObj.body;
       const fromMe = messageObj.fromMe;
@@ -91,7 +89,6 @@ function generateSummary(chats) {
       else neutralMessages++;
       if (fromMe) {
         enviadas++;
-        ultimaMsgFromMe = messageObj;
         lastFromMe = messageObj;
         // Se a anterior era do contato, calcula tempo de resposta
         if (lastFromContato) {
@@ -99,7 +96,6 @@ function generateSummary(chats) {
         }
       } else {
         recebidas++;
-        ultimaMsgFromContato = messageObj;
         lastFromContato = messageObj;
         // Se a anterior era sua, calcula tempo de resposta do contato
         if (lastFromMe) {


### PR DESCRIPTION
## Summary
- suporte a resumo de conversas dos últimos dias via variáveis de ambiente
- remove variáveis não utilizadas no summarizer
- ajusta cron para usar DEFAULT_SUMMARY_DAYS
- atualiza documentação

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855e00eac708333b60a9d4aa4f01e21