### PR TITLE
Atualiza Dockerfile para Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,30 @@
-FROM node:18.20.2-bookworm-slim
+FROM node:18-alpine
+
+# Diretório de trabalho da aplicação
 WORKDIR /app
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates fonts-liberation gnupg libasound2 libatk-bridge2.0-0 libatk1.0-0 \
-    libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 \
-    libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 \
-    libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 \
-    libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-    lsb-release wget xdg-utils --fix-missing && \
-    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
-    apt-get update && apt-get install -y google-chrome-stable && \
-    rm -rf /var/lib/apt/lists/*
+
+# Instala o Chromium e dependências básicas
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    harfbuzz \
+    ttf-freefont
+
+# Copia apenas arquivos de dependência para instalar módulos
 COPY package.json package-lock.json* ecosystem.config.js* ./
-RUN npm install --omit=dev --no-cache
+RUN npm ci --omit=dev
+
+# Copia o restante do código para o contêiner
 COPY . .
+
+# Prepara diretórios utilizados pela aplicação
 RUN mkdir -p /app/auth_data /app/logs && chown -R node:node /app
+
+ENV CHROMIUM_PATH=/usr/bin/chromium-browser \
+    PUPPETEER_SKIP_DOWNLOAD=true
+
 USER node
+
+# Comando de inicialização
 CMD ["node", "src/index.js"]


### PR DESCRIPTION
## Summary
- substitui base do Dockerfile para `node:18-alpine`
- instala `chromium` via apk e define `CHROMIUM_PATH`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856d3f787e88333969c412921c93364