### PR TITLE
Fix Docker build issue by skipping Chromium download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,12 @@ RUN apk add --no-cache \
 
 # Copia apenas arquivos de dependência para instalar módulos
 COPY package.json package-lock.json* ecosystem.config.js* ./
+
+# Define variáveis antes da instalação de dependências para evitar
+# download automático do Chromium pelo Puppeteer.
+ENV CHROMIUM_PATH=/usr/bin/chromium-browser \
+    PUPPETEER_SKIP_DOWNLOAD=true
+
 RUN npm ci --omit=dev
 
 # Copia o restante do código para o contêiner
@@ -20,9 +26,6 @@ COPY . .
 
 # Prepara diretórios utilizados pela aplicação
 RUN mkdir -p /app/auth_data /app/logs && chown -R node:node /app
-
-ENV CHROMIUM_PATH=/usr/bin/chromium-browser \
-    PUPPETEER_SKIP_DOWNLOAD=true
 
 USER node
 


### PR DESCRIPTION
## Summary
- adjust Dockerfile so that environment variables are set before installing dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856d5348e8883338f25a0101b6e0ceb