### PR TITLE
Fix Puppeteer install issue

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+puppeteer_skip_chromium_download=true


### PR DESCRIPTION
## Summary
- skip download of Chromium for puppeteer via `.npmrc`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856d65de6dc83339a281e80d74c5564