### PR TITLE
fix: ajustar cron e tratar participantes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 WHATSAPP_ADMIN_NUMBER=55999931227@c.us
 DEFAULT_SUMMARY_DAYS=7
-# Horário do agendamento diário no formato cron (padrão: "50 23 * * *")
-DAILY_SUMMARY_CRON=50 23 * * *
+# Horário do agendamento diário no formato cron (padrão: "0 19 * * *")
+DAILY_SUMMARY_CRON=0 19 * * *
 # Enviar resumo também por WhatsApp? "true" ou "false"
 WHATSAPP_NOTIFY=false
 EMAIL_USER=josemarschieste84@gmail.com

--- a/INSTRUCOES_SISTEMA.md
+++ b/INSTRUCOES_SISTEMA.md
@@ -5,7 +5,7 @@ Este documento resume todas as instruções fornecidas para o projeto **Whats-17
 ## 1. Tecnologias
 - **Cliente WhatsApp:** `whatsapp-web.js` usando `LocalAuth`.
 - **Servidor Web:** `Express.js` apenas para endpoint de *health check*.
-- **Agendamento de Tarefas:** `node-cron` com execução diária às **23:50**.
+- **Agendamento de Tarefas:** `node-cron` com execução diária às **19:00**.
 - **Envio de E-mails:** `Nodemailer` com conta Gmail.
 - **Logs:** `Winston` para registro de eventos e erros.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Bot de WhatsApp em Node.js voltado para registro de conversas e envio de resumos
 - **Comandos básicos**: responde `!ping` com `pong` e envia o resumo de pendências quando recebe `!pendencias` do administrador definido em `WHATSAPP_ADMIN_NUMBER`.
 - **Gerenciador de comandos**: cada comando é um módulo em `src/commands`, carregado dinamicamente na inicialização.
 - **Armazenamento de mensagens**: as mensagens são registradas em um banco SQLite (`data/messages.db`).
-- **Resumos automáticos**: uma tarefa `cron` é executada às 23:50 para salvar as conversas e disparar um e-mail com o resumo do dia.
+- **Resumos automáticos**: uma tarefa `cron` é executada às 19:00 para salvar as conversas e disparar um e-mail com o resumo do dia.
 - **Envio de e-mail**: utiliza `nodemailer` com uma conta Gmail para enviar resumos completos ou apenas de pendências.
 - **Servidor Express** para health check, útil em execuções via Docker ou PM2.
 - **Qualidade garantida**: ESLint e Prettier executam no pre-commit e há testes unitários com Jest.
@@ -38,7 +38,7 @@ Crie um arquivo `.env` baseado em `.env.example` com as variáveis abaixo:
 ```
 WHATSAPP_ADMIN_NUMBER=55999931227@c.us
 DEFAULT_SUMMARY_DAYS=7
-DAILY_SUMMARY_CRON=50 23 * * *
+DAILY_SUMMARY_CRON=0 19 * * *
 WHATSAPP_NOTIFY=false
 EMAIL_USER=josemarschieste84@gmail.com
 EMAIL_PASSWORD=senha_de_aplicativo

--- a/src/commands/group/todos.js
+++ b/src/commands/group/todos.js
@@ -5,8 +5,26 @@ module.exports = {
   description: 'Menciona todos os participantes do grupo.',
   category: 'group',
   async execute(message, args, client) {
-    const chat = await message.getChat();
+    let chat = await message.getChat();
     if (!chat.isGroup) return;
+
+    // Garante que a lista de participantes esteja disponível
+    if (!chat.participants) {
+      try {
+        chat = await client.getChatById(chat.id._serialized);
+      } catch (err) {
+        logger.warn(
+          `Não foi possível obter metadados do grupo ${chat.id._serialized}: ${err.message}`
+        );
+        return;
+      }
+    }
+
+    if (!chat.participants) {
+      logger.warn(`Metadados do grupo ${chat.name} não contêm participantes.`);
+      return;
+    }
+
     let text = '';
     const mentions = [];
     for (const participant of chat.participants) {

--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ client.on('ready', () => {
   logger.info('Cliente do WhatsApp está pronto!');
 
   // Agendamento de tarefas com node-cron
-  const summaryCron = process.env.DAILY_SUMMARY_CRON || '50 23 * * *';
+  const summaryCron = process.env.DAILY_SUMMARY_CRON || '0 19 * * *';
   cron.schedule(
     summaryCron,
     async () => {


### PR DESCRIPTION
## Summary
- handle missing participants when running `!todos`
- move daily summary cron to 19:00
- update example env vars and docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859c85cc5e08333b8a6661314004177