### PR TITLE
Fix Chrome path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ O `DEFAULT_SUMMARY_DAYS` controla quantos dias entram no resumo diário automát
 Com `WHATSAPP_NOTIFY` ajustado para `true`, o bot enviará o resumo para o WhatsApp do administrador além do e-mail.
 Para que o envio de e-mails funcione é necessário criar uma senha de aplicativo no Gmail e habilitar o acesso às APIs necessárias.
 
+Se o caminho definido em `CHROMIUM_PATH` não existir, instale o Google Chrome ou deixe a variável vazia para usar o Chromium fornecido pelo Puppeteer.
+
 ## Executando localmente
 
 1. Instale as dependências:

--- a/src/index.js
+++ b/src/index.js
@@ -56,19 +56,25 @@ logger.info('Configurando o cliente do WhatsApp...');
 const client = new Client({
   // Persistência da sessão em diretório dedicado
   authStrategy: new LocalAuth({ dataPath: './session_data' }),
-  puppeteer: {
-    headless: true,
-    args: [
-      '--no-sandbox',
-      '--disable-setuid-sandbox',
-      '--disable-dev-shm-usage',
-      '--disable-accelerated-2d-canvas',
-      '--no-first-run',
-      '--no-zygote',
-      '--disable-gpu'
-    ],
-    executablePath: process.env.CHROMIUM_PATH || '/usr/bin/google-chrome-stable'
-  }
+  puppeteer: (() => {
+    const baseConfig = {
+      headless: true,
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+        '--disable-accelerated-2d-canvas',
+        '--no-first-run',
+        '--no-zygote',
+        '--disable-gpu'
+      ]
+    };
+
+    const chromiumPath = process.env.CHROMIUM_PATH;
+    if (chromiumPath) baseConfig.executablePath = chromiumPath;
+
+    return baseConfig;
+  })()
 });
 
 // Coleção que armazenará os comandos


### PR DESCRIPTION
## Summary
- only set `executablePath` when CHROMIUM_PATH is provided
- add tip on Chrome path in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859cb11ca1c8333924b432941d20535