### PR TITLE
Corrige comando todos e ajusta dependências

### DIFF
--- a/src/commands/group/todos.js
+++ b/src/commands/group/todos.js
@@ -5,34 +5,45 @@ module.exports = {
   description: 'Menciona todos os participantes do grupo.',
   category: 'group',
   async execute(message, args, client) {
-    let chat = await message.getChat();
-    if (!chat.isGroup) return;
-
-    // Garante que a lista de participantes esteja disponível
-    if (!chat.participants) {
+    try {
+      let chat;
       try {
-        chat = await client.getChatById(chat.id._serialized);
+        chat = await message.getChat();
       } catch (err) {
-        logger.warn(
-          `Não foi possível obter metadados do grupo ${chat.id._serialized}: ${err.message}`
-        );
+        logger.warn(`Falha ao obter chat: ${err.message}`);
         return;
       }
-    }
 
-    if (!chat.participants) {
-      logger.warn(`Metadados do grupo ${chat.name} não contêm participantes.`);
-      return;
-    }
+      if (!chat.isGroup) return;
 
-    let text = '';
-    const mentions = [];
-    for (const participant of chat.participants) {
-      const contact = await client.getContactById(participant.id._serialized);
-      mentions.push(contact);
-      text += `@${participant.id.user} `;
+      // Garante que a lista de participantes esteja disponível
+      if (!chat.participants || chat.participants.length === 0) {
+        try {
+          chat = await client.getChatById(chat.id._serialized);
+        } catch (err) {
+          logger.warn(
+            `Não foi possível obter metadados do grupo ${chat.id._serialized}: ${err.message}`
+          );
+          return;
+        }
+      }
+
+      if (!Array.isArray(chat.participants) || chat.participants.length === 0) {
+        logger.warn(`Metadados do grupo ${chat.name} não contêm participantes.`);
+        return;
+      }
+
+      let text = '';
+      const mentions = [];
+      for (const participant of chat.participants) {
+        const contact = await client.getContactById(participant.id._serialized);
+        mentions.push(contact);
+        text += `@${participant.id.user} `;
+      }
+      await chat.sendMessage(text.trim(), { mentions });
+      logger.info(`[AÇÃO GRUPO] Marquei todos no grupo "${chat.name}".`);
+    } catch (err) {
+      logger.error('Erro no comando todos:', err);
     }
-    await chat.sendMessage(text, { mentions });
-    logger.info(`[AÇÃO GRUPO] Marquei todos no grupo "${chat.name}".`);
   }
 };


### PR DESCRIPTION
## Summary
- melhorar o comando `todos` para evitar falhas ao obter participantes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859ce76369c833388abf0bfa2fe92ae