### PR TITLE
Fix Chromium setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ Thumbs.db
 # PM2
 *.pid
 *.launch
+/session_data

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-puppeteer_skip_chromium_download=true
+puppeteer_skip_chromium_download=false

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Com `WHATSAPP_NOTIFY` ajustado para `true`, o bot enviará o resumo para o Whats
 Para que o envio de e-mails funcione é necessário criar uma senha de aplicativo no Gmail e habilitar o acesso às APIs necessárias.
 
 Se o caminho definido em `CHROMIUM_PATH` não existir, instale o Google Chrome ou deixe a variável vazia para usar o Chromium fornecido pelo Puppeteer.
+Se preferir nao instalar o Chrome, certifique-se de que o arquivo `.npmrc` tenha `puppeteer_skip_chromium_download=false` para que o Puppeteer baixe o Chromium automaticamente.
 
 ## Executando localmente
 


### PR DESCRIPTION
## Summary
- allow Puppeteer to download Chromium by default
- ignore `session_data` folder created by the bot
- document how to let Puppeteer fetch the browser when Chrome isn't installed

## Testing
- `npm test`
- `npm run lint`
- `node src/index.js` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_6859d23073b083339b35e46c6d500bcf