### PR TITLE
Fix puppeteer config to enable chromium download

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-puppeteer_skip_chromium_download=true
+puppeteer_skip_chromium_download=false


### PR DESCRIPTION
## Summary
- enable Chromium download by default

## Testing
- `npm test`
- `npm run lint`
- `node node_modules/whatsapp-web.js/node_modules/puppeteer/install.js` *(fails: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_6859e52931d483338564bf8929167dca