### PR TITLE
Remove CHROMIUM_PATH configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,3 @@ WHATSAPP_NOTIFY=false
 EMAIL_USER=josemarschieste84@gmail.com
 EMAIL_PASSWORD=senha_de_aplicativo
 EMAIL_TO=schieste87@gmail.com
-# Caminho para o executável do Chrome em ambientes de produção
-# (ajuste se necessário)
-CHROMIUM_PATH=/usr/bin/google-chrome-stable

--- a/README.md
+++ b/README.md
@@ -43,16 +43,12 @@ WHATSAPP_NOTIFY=false
 EMAIL_USER=josemarschieste84@gmail.com
 EMAIL_PASSWORD=senha_de_aplicativo
 EMAIL_TO=schieste87@gmail.com
-CHROMIUM_PATH=/usr/bin/google-chrome-stable
 ```
 O valor de `WHATSAPP_ADMIN_NUMBER` define qual contato está autorizado a usar o comando `!pendencias`.
 O `DEFAULT_SUMMARY_DAYS` controla quantos dias entram no resumo diário automático.
 `DAILY_SUMMARY_CRON` permite ajustar o horário da tarefa de resumo sem alterar o código.
 Com `WHATSAPP_NOTIFY` ajustado para `true`, o bot enviará o resumo para o WhatsApp do administrador além do e-mail.
 Para que o envio de e-mails funcione é necessário criar uma senha de aplicativo no Gmail e habilitar o acesso às APIs necessárias.
-
-Se o caminho definido em `CHROMIUM_PATH` não existir, instale o Google Chrome ou deixe a variável vazia para usar o Chromium fornecido pelo Puppeteer.
-Se preferir nao instalar o Chrome, certifique-se de que o arquivo `.npmrc` tenha `puppeteer_skip_chromium_download=false` para que o Puppeteer baixe o Chromium automaticamente.
 
 ## Executando localmente
 

--- a/src/index.js
+++ b/src/index.js
@@ -70,9 +70,6 @@ const client = new Client({
       ]
     };
 
-    const chromiumPath = process.env.CHROMIUM_PATH;
-    if (chromiumPath) baseConfig.executablePath = chromiumPath;
-
     return baseConfig;
   })()
 });


### PR DESCRIPTION
## Summary
- remove `CHROMIUM_PATH` usage from source code
- delete the variable from example environment file
- update README to no longer mention Chromium path

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859e75377d08333a6c37af36de44d88