### PR TITLE
Resolve falha na inicialização do cliente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,5 @@ EMAIL_USER=josemarschieste84@gmail.com
 EMAIL_PASSWORD=senha_de_aplicativo
 EMAIL_TO=schieste87@gmail.com
 # Caminho para o executável do Chrome (opcional)
-CHROMIUM_PATH=/usr/bin/google-chrome-stable
+# Deixe em branco para usar o Chromium baixado automaticamente pelo Puppeteer
+CHROMIUM_PATH=

--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ WHATSAPP_NOTIFY=false
 EMAIL_USER=josemarschieste84@gmail.com
 EMAIL_PASSWORD=senha_de_aplicativo
 EMAIL_TO=schieste87@gmail.com
-CHROMIUM_PATH=/usr/bin/google-chrome-stable
+# Opcional: defina se possuir o Chrome instalado
+CHROMIUM_PATH=
 ```
 O valor de `WHATSAPP_ADMIN_NUMBER` define qual contato está autorizado a usar o comando `!pendencias`.
 O `DEFAULT_SUMMARY_DAYS` controla quantos dias entram no resumo diário automático.
-Caso nao possua o Chrome instalado, mantenha o arquivo `.npmrc` com `puppeteer_skip_chromium_download=false` para que o Puppeteer baixe o Chromium automaticamente.
+Caso nao possua o Chrome instalado, mantenha o arquivo `.npmrc` com `puppeteer_skip_chromium_download=false` para que o Puppeteer baixe o Chromium automaticamente. Se `CHROMIUM_PATH` estiver em branco, o download ocorrerá durante a instalação das dependências.
 `DAILY_SUMMARY_CRON` permite ajustar o horário da tarefa de resumo sem alterar o código.
 Com `WHATSAPP_NOTIFY` ajustado para `true`, o bot enviará o resumo para o WhatsApp do administrador além do e-mail.
 Para que o envio de e-mails funcione é necessário criar uma senha de aplicativo no Gmail e habilitar o acesso às APIs necessárias.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "node-cron": "^3.0.3",
         "nodemailer": "^6.9.9",
         "pm2": "^6.0.8",
-        "puppeteer": "npm:puppeteer-core@^22.10.0",
+        "puppeteer": "^22.10.0",
         "qrcode-terminal": "^0.12.0",
         "quickchart-js": "^3.1.0",
         "remove-accents": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "whatsapp-web.js": "^1.30.0",
     "winston": "^3.11.0",
     "winston-daily-rotate-file": "^4.7.1",
-    "puppeteer": "npm:puppeteer-core@^22.10.0"
+    "puppeteer": "^22.10.0"
   },
   "devDependencies": {
     "eslint-config-prettier": "^10.1.5",

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,17 @@ const client = new Client({
     };
 
     const chromiumPath = process.env.CHROMIUM_PATH;
-    if (chromiumPath) baseConfig.executablePath = chromiumPath;
+    if (chromiumPath) {
+      try {
+        if (fs.existsSync(chromiumPath)) {
+          baseConfig.executablePath = chromiumPath;
+        } else {
+          logger.warn(`Caminho definido em CHROMIUM_PATH nao encontrado: ${chromiumPath}`);
+        }
+      } catch (err) {
+        logger.warn(`Falha ao acessar CHROMIUM_PATH (${chromiumPath}): ${err.message}`);
+      }
+    }
 
     return baseConfig;
   })()


### PR DESCRIPTION
## Summary
- instalar Puppeteer completo para baixar o Chromium
- tornar CHROMIUM_PATH opcional no exemplo de env
- documentar configuração opcional do Chromium
- verificar validade do caminho em `index.js`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a726bdfd48333bfb12ebf6fbff7d8