### PR TITLE
fix: add single-process to puppeteer config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,7 @@ const client = new Client({
         '--disable-accelerated-2d-canvas',
         '--no-first-run',
         '--no-zygote',
+        '--single-process',
         '--disable-gpu'
       ]
     };


### PR DESCRIPTION
## Summary
- add missing `--single-process` argument to the Puppeteer config in `src/index.js`

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a771234b88333918ada1128550f41