### PR TITLE
fix: atualizar agendamento do resumo para 16h

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 WHATSAPP_ADMIN_NUMBER=55999931227@c.us
 DEFAULT_SUMMARY_DAYS=7
-# Horário do agendamento diário no formato cron (padrão: "50 20 * * *")
-DAILY_SUMMARY_CRON=50 20 * * *
+# Horário do agendamento diário no formato cron (padrão: "0 19 * * *" - 16:00 BRT)
+DAILY_SUMMARY_CRON=0 19 * * *
 # Enviar resumo também por WhatsApp? "true" ou "false"
 WHATSAPP_NOTIFY=false
 EMAIL_USER=josemarschieste84@gmail.com

--- a/INSTRUCOES_SISTEMA.md
+++ b/INSTRUCOES_SISTEMA.md
@@ -5,7 +5,7 @@ Este documento resume todas as instruções fornecidas para o projeto **Whats-17
 ## 1. Tecnologias
 - **Cliente WhatsApp:** `whatsapp-web.js` usando `LocalAuth`.
 - **Servidor Web:** `Express.js` apenas para endpoint de *health check*.
-- **Agendamento de Tarefas:** `node-cron` com execução diária às **20:50**.
+- **Agendamento de Tarefas:** `node-cron` com execução diária às **16:00 BRT (19:00 UTC)**.
 - **Envio de E-mails:** `Nodemailer` com conta Gmail.
 - **Logs:** `Winston` para registro de eventos e erros.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Bot de WhatsApp em Node.js voltado para registro de conversas e envio de resumos
 - **Gerenciador de comandos**: cada comando é um módulo em `src/commands`, carregado dinamicamente na inicialização.
 - **Armazenamento de mensagens**: registros em banco SQLite (`data/messages.db`), via `src/database.js`.
 - **Sessão persistente**: autenticação usando `LocalAuth` com dados salvos em `session_data/`.
-- **Resumos automáticos**: tarefa `cron` diária (20:50 por padrão) que salva as conversas e dispara um e-mail.
+- **Resumos automáticos**: tarefa `cron` diária (16:00 BRT por padrão) que salva as conversas e dispara um e-mail.
 - **Envio de e-mail**: `nodemailer` configurado para Gmail envia resumos completos ou apenas pendências.
 - **Análise de mensagens**: `src/summarizer.js` usa as libs `sentiment` e `compromise` para detectar sentimento, tópicos e pendências.
 - **Servidor Express** para health check em `/health` (porta `8080` por padrão).
@@ -43,7 +43,7 @@ Crie um arquivo `.env` baseado em `.env.example` com as variáveis abaixo:
 ```
 WHATSAPP_ADMIN_NUMBER=55999931227@c.us
 DEFAULT_SUMMARY_DAYS=7
-DAILY_SUMMARY_CRON=50 20 * * *
+DAILY_SUMMARY_CRON=0 19 * * *
 WHATSAPP_NOTIFY=false
 EMAIL_USER=josemarschieste84@gmail.com
 EMAIL_PASSWORD=uiydrinsudkzsuqi

--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,8 @@ client.on('ready', () => {
   logger.info('Cliente do WhatsApp está pronto!');
 
   // Agendamento de tarefas com node-cron
-  const summaryCron = process.env.DAILY_SUMMARY_CRON || '50 20 * * *';
+  // Executa todo dia às 19:00 UTC (16:00 BRT) por padrão
+  const summaryCron = process.env.DAILY_SUMMARY_CRON || '0 19 * * *';
   cron.schedule(
     summaryCron,
     async () => {


### PR DESCRIPTION
## Summary
- executa cron diário às 16h BRT (19h UTC) por padrão
- ajusta exemplos de configuração
- atualiza documentação

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d1191c65883338d29ce3990184525