### PR TITLE
Fix email summary for empty chats

### DIFF
--- a/src/emailer.js
+++ b/src/emailer.js
@@ -122,9 +122,8 @@ async function sendSummaryForDate(dateStr) {
   const chats = loadChatsByDate(dateStr);
   if (!chats || chats.length === 0) {
     logger.info(`Nenhuma conversa encontrada para ${dateStr}`);
-    return '';
   }
-  return await sendDailySummary(chats);
+  return await sendDailySummary(chats || []);
 }
 
 /**
@@ -135,7 +134,6 @@ async function sendSummaryForLastDays(days) {
   const chats = loadChatsForLastDays(days);
   if (chats.length === 0) {
     logger.info(`Nenhuma conversa encontrada nos últimos ${days} dias`);
-    return '';
   }
   return await sendDailySummary(chats);
 }


### PR DESCRIPTION
## Summary
- avoid skipping email when no messages are found

## Testing
- `npm test` *(fails: jest not found)*
- `node src/scripts/test-summary.js` *(fails: cannot find module 'winston')*

------
https://chatgpt.com/codex/tasks/task_e_685dccfd8d488333af54b695962c419b