### PR TITLE
Atualiza README com funcionalidades recentes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ Bot de WhatsApp em Node.js voltado para registro de conversas e envio de resumos
 
 - **Integração com o WhatsApp** através da biblioteca `whatsapp-web.js` com autenticação `LocalAuth`.
 - **Comandos básicos**: responde `!ping` com `pong` e envia o resumo de pendências quando recebe `!pendencias` do administrador definido em `WHATSAPP_ADMIN_NUMBER`.
+- **Comando `!resumo-hoje`**: gera um resumo do dia atual ou de uma data informada (DD/MM/YYYY) e envia para o administrador.
 - **Gerenciador de comandos**: cada comando é um módulo em `src/commands`, carregado dinamicamente na inicialização.
 - **Armazenamento de mensagens**: registros em banco SQLite (`data/messages.db`), via `src/database.js`.
 - **Sessão persistente**: autenticação usando `LocalAuth` com dados salvos em `session_data/`.
 - **Resumos automáticos**: tarefa `cron` diária (16:00 BRT por padrão) que salva as conversas e dispara um e-mail.
 - **Envio de e-mail**: `nodemailer` configurado para Gmail envia resumos completos ou apenas pendências.
+- **Suporte a múltiplos administradores** via `ADMIN_WHATSAPP_IDS` (lista separada por vírgulas).
 - **Análise de mensagens**: `src/summarizer.js` usa as libs `sentiment` e `compromise` para detectar sentimento, tópicos e pendências.
 - **Servidor Express** para health check em `/health` (porta `8080` por padrão).
 - **Logs estruturados**: `winston` com rotação diária em `logs/`.
@@ -42,6 +44,7 @@ Crie um arquivo `.env` baseado em `.env.example` com as variáveis abaixo:
 
 ```
 WHATSAPP_ADMIN_NUMBER=55999931227@c.us
+ADMIN_WHATSAPP_IDS=559999999999@c.us,559999999998@c.us
 DEFAULT_SUMMARY_DAYS=7
 DAILY_SUMMARY_CRON=0 16 * * *
 WHATSAPP_NOTIFY=false
@@ -51,7 +54,8 @@ EMAIL_TO=schieste87@gmail.com
 # Porta usada pelo servidor Express opcional
 PORT=8080
 ```
-O valor de `WHATSAPP_ADMIN_NUMBER` define qual contato está autorizado a usar o comando `!pendencias`.
+O valor de `WHATSAPP_ADMIN_NUMBER` define quem pode usar o comando `!pendencias`.
+A variável `ADMIN_WHATSAPP_IDS` contém uma lista de administradores separados por vírgula. O primeiro da lista recebe o resumo diário e pode usar `!resumo-hoje`.
 O `DEFAULT_SUMMARY_DAYS` controla quantos dias entram no resumo diário automático.
 `PORT` permite escolher a porta do endpoint `/health` usado para monitorar o bot.
 Caso nao possua o Chrome instalado, mantenha o arquivo `.npmrc` com `puppeteer_skip_chromium_download=false` para que o Puppeteer baixe o Chromium automaticamente.
@@ -97,6 +101,7 @@ Para testar o envio de e-mails sem precisar aguardar o agendamento, execute:
 ```bash
 node src/scripts/test-summary.js
 ```
+Você também pode gerar um resumo do dia pelo WhatsApp enviando o comando `!resumo-hoje`.
 
 ## Considerações adicionais
 
@@ -105,7 +110,7 @@ node src/scripts/test-summary.js
 - Caso deseje personalizar as regras de estilo, utilize os arquivos `.eslintrc.jsonc` e `.prettierrc`.
 - O horário do resumo pode ser alterado ajustando a variável `DAILY_SUMMARY_CRON` no `.env`.
 
-# Versão 1.1
+# Versão 1.2
 
 ## Deploy no Coolify
 


### PR DESCRIPTION
## Resumo
- inclui documentacao do comando `!resumo-hoje`
- explica suporte a multiplos administradores com variavel `ADMIN_WHATSAPP_IDS`
- atualiza secao de configuracao com nova variavel
- adiciona nota sobre gerar resumo via WhatsApp
- incrementa versao da documentacao para 1.2

## Testes
- `npm test` *(falhou: jest nao encontrado)*
- `npm install` *(falhou: download do Chromium bloqueado)*

------
https://chatgpt.com/codex/tasks/task_e_686096b0687083338a8c05d92ed705ad