### PR TITLE
Adicionar comando !ajuda e refinar resumos

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -17,3 +17,36 @@ Exemplo:
 ```
 !pendencias
 ```
+
+## !resumo-hoje
+Gera um resumo das conversas de uma data ou intervalo. Se usado sem parâmetros, considera o dia atual.
+
+Exemplos:
+```
+!resumo-hoje
+!resumo-hoje 01/02/2024 05/02/2024
+```
+
+## !todos
+Menciona todos os participantes do grupo atual.
+
+Exemplo:
+```
+!todos
+```
+
+## !test-email
+Dispara um e-mail de teste para validar as credenciais configuradas.
+
+Exemplo:
+```
+!test-email
+```
+
+## !ajuda
+Lista todos os comandos disponíveis conforme este documento.
+
+Exemplo:
+```
+!ajuda
+```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Bot de WhatsApp em Node.js voltado para registro de conversas e envio de resumos
 - **Servidor Express** para health check em `/health` (porta `8080` por padrão).
 - **Logs estruturados**: `winston` com rotação diária em `logs/`.
 - **Qualidade garantida**: ESLint, Prettier e testes unitários com Jest.
+## Fluxo Simplificado
+
+```mermaid
+graph TD
+  A[Usuário no WhatsApp] -->|mensagens| B(Bot)
+  B --> C{Comandos}
+  C -->|salvar| D[SQLite]
+  C -->|resumo diário| E[cron 23:50]
+  E --> F[Gerar resumo]
+  F --> G[Nodemailer]
+  G --> H[E-mail do Admin]
+```
+
 
 ## Estrutura do repositório
 
@@ -40,11 +53,21 @@ INSTRUCOES_DEPLOY.md - Passo a passo de configuração na Coolify
 
 ## Comandos do Bot
 
+- `!ajuda` – lista todos os comandos disponíveis.
 - `!ping` – responde "pong" para verificar se o bot está online.
 - `!pendencias` – envia ao administrador um resumo de perguntas sem resposta do dia.
-- `!resumo-hoje` – gera um resumo completo das conversas do dia (ou data informada).
+- `!resumo-hoje` – gera um resumo das conversas de uma data ou intervalo (ex.: `!resumo-hoje 01/02/2024 05/02/2024`).
 - `!todos` – menciona todos os participantes de um grupo.
 - `!test-email` – dispara um e-mail de teste para validar as credenciais.
+### Exemplos
+```bash
+!ajuda
+!ping
+!pendencias
+!resumo-hoje 01/02/2024 05/02/2024
+!todos
+!test-email
+```
 
 ## Configuração
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,28 @@
+# Arquitetura do Projeto
+
+Este documento resume a organização de pastas e módulos principais do bot.
+
+```text
+Whats-17-06/
+├── src/
+│   ├── index.js            # Inicialização do bot e agendamentos
+│   ├── database.js         # Persistência em SQLite
+│   ├── emailer.js          # Envio de e-mails
+│   ├── logger.js           # Configuração do Winston
+│   ├── summarizer.js       # Geração de resumos e pendências
+│   ├── commands/
+│   │   ├── group/
+│   │   │   └── todos.js
+│   │   └── util/
+│   │       ├── ajuda.js
+│   │       ├── pendencias.js
+│   │       ├── ping.js
+│   │       ├── resumo-hoje.js
+│   │       └── test-email.js
+│   └── __tests__/          # Testes automatizados
+├── data/                   # Banco SQLite
+├── logs/                   # Arquivos de log
+└── COMMANDS.md             # Documentação rápida de comandos
+```
+
+Os módulos se comunicam de forma simples: `index.js` recebe mensagens via `whatsapp-web.js`, salva tudo no `database.js` e, quando necessário, gera resumos com `summarizer.js` e envia e-mails usando `emailer.js`.

--- a/src/commands/util/ajuda.js
+++ b/src/commands/util/ajuda.js
@@ -1,0 +1,32 @@
+const logger = require('../../logger');
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+  name: 'ajuda',
+  description: 'Lista todos os comandos disponíveis.',
+  category: 'util',
+  async execute(message) {
+    try {
+      const commandsPath = path.resolve(__dirname, '../../../COMMANDS.md');
+      const md = await fs.promises.readFile(commandsPath, 'utf8');
+      const regex = /^##\s+(!\S+)\n([^#]+)/gm;
+      const comandos = [];
+      let match;
+      while ((match = regex.exec(md)) !== null) {
+        const nome = match[1];
+        const desc = match[2].split('\n')[0].trim();
+        comandos.push(`${nome} - ${desc}`);
+      }
+      if (comandos.length === 0) {
+        await message.reply('Nenhum comando encontrado em COMMANDS.md.');
+        return;
+      }
+      const resposta = `*Comandos disponíveis:*\n${comandos.join('\n')}`;
+      await message.reply(resposta);
+    } catch (error) {
+      logger.error('Erro ao carregar comandos:', error);
+      await message.reply('Não foi possível carregar a lista de comandos.');
+    }
+  }
+};

--- a/src/commands/util/pendencias.js
+++ b/src/commands/util/pendencias.js
@@ -21,7 +21,10 @@ module.exports = {
       const messages = await db.getMessagesByDate(todayStr);
 
       if (!messages || messages.length === 0) {
-        await client.sendMessage(message.from, "Nenhuma mensagem registrada hoje para gerar resumo de pendências.");
+        await client.sendMessage(
+          message.from,
+          'Nenhuma mensagem registrada hoje para gerar resumo de pendências.'
+        );
         return;
       }
 
@@ -29,17 +32,25 @@ module.exports = {
       const resumoPendencias = generatePendingSummary(messages);
 
       if (!resumoPendencias || resumoPendencias.trim() === '') {
-        await client.sendMessage(message.from, "Nenhuma pendência encontrada nas conversas de hoje.");
+        await client.sendMessage(
+          message.from,
+          'Nenhuma pendência encontrada nas conversas de hoje.'
+        );
         return;
       }
 
       // Envia o resumo como mensagem para o administrador
-      await client.sendMessage(message.from, `📋 *Resumo de Pendências de Hoje:*
-\n${resumoPendencias}`);
-
+      await client.sendMessage(
+        message.from,
+        `📋 *Resumo de Pendências de Hoje:*\n${resumoPendencias}`
+      );
+      await client.sendMessage(message.from, '✅ Resumo de pendências enviado.');
     } catch (error) {
       logger.error('Erro ao executar o comando !pendencias:', error);
-      await client.sendMessage(message.from, 'Ocorreu um erro ao gerar o resumo de pendências. Verifique os logs.');
+      await client.sendMessage(
+        message.from,
+        'Ocorreu um erro ao gerar o resumo de pendências. Verifique os logs.'
+      );
     }
   }
 };

--- a/src/commands/util/resumo-hoje.js
+++ b/src/commands/util/resumo-hoje.js
@@ -2,66 +2,87 @@ const db = require('../../database');
 const { createDailySummary } = require('../../summarizer');
 const logger = require('../../logger');
 
+function parseDate(str) {
+  const parts = str.split('/');
+  if (parts.length !== 3) return null;
+  const [d, m, y] = parts;
+  if (d.length !== 2 || m.length !== 2 || y.length !== 4) return null;
+  const iso = `${y}-${m}-${d}`;
+  return new Date(`${iso}T00:00:00`);
+}
+
 module.exports = {
   name: 'resumo-hoje',
-  description: 'Envia o resumo das conversas de um dia específico (ou de hoje) para o administrador.',
-  async execute(msg, args) { // Adiciona args
+  description: 'Envia o resumo das conversas de um dia ou intervalo para o administrador.',
+  async execute(msg, args) {
     const adminIds = (process.env.ADMIN_WHATSAPP_IDS || '').split(',').map(id => id.trim());
     const senderId = msg.from;
 
-    // Se a lista de admins estiver vazia, ninguém pode usar.
     if (adminIds.length === 0 || !adminIds[0]) {
-        logger.warn('Comando !resumo-hoje: ADMIN_WHATSAPP_IDS não definido no .env.');
-        // Não envia resposta para evitar spam
-        return;
+      logger.warn('Comando !resumo-hoje: ADMIN_WHATSAPP_IDS não definido no .env.');
+      return;
     }
 
-    // Apenas administradores podem executar este comando
     if (!adminIds.includes(senderId)) {
       await msg.reply('Você não tem permissão para usar este comando.');
       return;
     }
 
-    // O ID do administrador que receberá a mensagem é quem executou o comando
     const adminContactId = senderId;
 
-    // Verifica se uma data foi fornecida, senão usa a data atual
-    let dateStringForDb;
-    let friendlyDate;
+    let startDate;
+    let endDate;
 
-    if (args && args.length > 0) {
-      const dateParts = args[0].split('/');
-      if (dateParts.length === 3 && dateParts[0].length === 2 && dateParts[1].length === 2 && dateParts[2].length === 4) {
-        // Formato DD/MM/YYYY -> YYYY-MM-DD para o banco de dados
-        dateStringForDb = `${dateParts[2]}-${dateParts[1]}-${dateParts[0]}`;
-        friendlyDate = args[0];
-      } else {
+    if (args && args.length >= 2) {
+      startDate = parseDate(args[0]);
+      endDate = parseDate(args[1]);
+      if (!startDate || !endDate) {
         await msg.reply('Formato de data inválido. Use DD/MM/YYYY.');
         return;
       }
+    } else if (args && args.length === 1) {
+      startDate = parseDate(args[0]);
+      if (!startDate) {
+        await msg.reply('Formato de data inválido. Use DD/MM/YYYY.');
+        return;
+      }
+      endDate = new Date(startDate);
     } else {
-      // Usa o fuso horário de São Paulo para garantir que a data seja a correta
-      const today = new Date(new Date().toLocaleString("en-US", {timeZone: "America/Sao_Paulo"}));
-      dateStringForDb = today.toISOString().slice(0, 10);
-      friendlyDate = today.toLocaleDateString('pt-BR');
+      const today = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Sao_Paulo' }));
+      startDate = today;
+      endDate = new Date(today);
     }
 
-    try {
-      // Usa client.sendMessage em vez de reply para maior robustez
-      await msg.client.sendMessage(adminContactId, `Gerando o resumo do dia ${friendlyDate}, por favor aguarde...`);
-      const chats = await db.getMessagesByDate(dateStringForDb);
+    if (startDate > endDate) {
+      const temp = startDate;
+      startDate = endDate;
+      endDate = temp;
+    }
 
-      if (!chats || chats.length === 0) {
-        const replyText = `Nenhuma conversa encontrada para o dia ${friendlyDate}.`;
-        await msg.client.sendMessage(adminContactId, replyText);
+    const friendlyStart = startDate.toLocaleDateString('pt-BR');
+    const friendlyEnd = endDate.toLocaleDateString('pt-BR');
+    const friendlyRange = friendlyStart === friendlyEnd ? friendlyStart : `${friendlyStart} até ${friendlyEnd}`;
+
+    try {
+      await msg.client.sendMessage(adminContactId, `Gerando o resumo de ${friendlyRange}, por favor aguarde...`);
+
+      let allMessages = [];
+      for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+        const iso = d.toISOString().slice(0, 10);
+        const dayMsgs = await db.getMessagesByDate(iso);
+        allMessages = allMessages.concat(dayMsgs);
+      }
+
+      if (!allMessages || allMessages.length === 0) {
+        await msg.client.sendMessage(adminContactId, `Nenhuma conversa encontrada para o período ${friendlyRange}.`);
         return;
       }
 
-      const summaryText = await createDailySummary(chats);
-      
-      await msg.client.sendMessage(adminContactId, summaryText);
-      logger.info(`Resumo do dia ${friendlyDate} enviado manualmente para ${adminContactId} a pedido de ${msg.from}.`);
+      const summaryText = await createDailySummary(allMessages);
 
+      await msg.client.sendMessage(adminContactId, summaryText);
+      await msg.client.sendMessage(adminContactId, '✅ Resumo enviado.');
+      logger.info(`Resumo do período ${friendlyRange} enviado para ${adminContactId} a pedido de ${msg.from}.`);
     } catch (error) {
       logger.error(`Erro no comando !resumo-hoje: ${error.message}`);
       await msg.reply('Ocorreu um erro ao gerar ou enviar o resumo.');


### PR DESCRIPTION
## Resumo
- criar `!ajuda` para listar comandos
- permitir intervalo de datas em `!resumo-hoje`
- confirmar ações críticas em `!pendencias` e `!resumo-hoje`
- adicionar fluxograma e exemplos ao README
- documentar arquitetura do projeto

## Testes
- `npm run lint`
- `npm test` *(falhou: jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686123bda098833387a23aaeaa408e88